### PR TITLE
fix(auth): pass username argument to OAuth2Flow

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -56,10 +56,15 @@ func createAuthBearerCmd(a *auth.Auth) *cobra.Command {
 
 func createAuthOAuth2Cmd(a *auth.Auth) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "oauth2",
+		Use:   "oauth2 [USERNAME]",
 		Short: "Configure OAuth2 authentication",
+		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			_, err := a.OAuth2Flow("")
+			username := ""
+			if len(args) > 0 {
+				username = args[0]
+			}
+			_, err := a.OAuth2Flow(username)
 			if err != nil {
 				fmt.Println("OAuth2 authentication failed:", err)
 				os.Exit(1)


### PR DESCRIPTION
## Summary

- `auth oauth2` always passes `""` to `OAuth2Flow()`, ignoring any positional `USERNAME` argument
- This forces the flow through `fetchUsername()` → `GET /2/users/me`, which has been returning 403 for many developers since the March 2026 platform regression
- When a username is provided (`xurl auth oauth2 alice`), it should be passed through so `OAuth2Flow` skips the broken lookup and stores the token directly

## Changes

One-line fix in `cli/auth.go`: read `args[0]` when present and pass it to `a.OAuth2Flow(username)` instead of hardcoded `""`.

## Test plan

- [x] `xurl auth oauth2 <username>` completes successfully (skips `/2/users/me`)
- [x] `xurl auth oauth2` (no args) retains existing behavior (calls `fetchUsername`)
- [x] `xurl auth status` shows the token stored under the provided username
- [x] `xurl whoami` works with the stored token

Fixes #47