### PR TITLE
fix(windows): OAuth2 auth flow is broken when opening the browser

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -461,20 +461,17 @@ func getOAuth2Scopes() []string {
 }
 
 func openBrowser(url string) error {
-	var cmd string
-	var args []string
-
-	switch runtime.GOOS {
-	case "windows":
-		cmd = "cmd"
-		args = []string{"/c", "start", url}
-	case "darwin":
-		cmd = "open"
-		args = []string{url}
-	default:
-		cmd = "xdg-open"
-		args = []string{url}
-	}
-
+	cmd, args := browserLaunchCommand(runtime.GOOS, url)
 	return exec.Command(cmd, args...).Start()
+}
+
+func browserLaunchCommand(goos, url string) (string, []string) {
+	switch goos {
+	case "windows":
+		return "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	case "darwin":
+		return "open", []string{url}
+	default:
+		return "xdg-open", []string{url}
+	}
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -264,3 +264,28 @@ func TestGetOAuth2HeaderNoToken(t *testing.T) {
 	token := tokenStore.GetOAuth2Token("nobody")
 	assert.Nil(t, token)
 }
+
+func TestBrowserLaunchCommand(t *testing.T) {
+	url := "https://x.com/i/oauth2/authorize?client_id=abc&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback&response_type=code&scope=tweet.read+users.read&state=123&code_challenge=xyz&code_challenge_method=S256"
+
+	t.Run("windows keeps the full oauth url as a single argument", func(t *testing.T) {
+		cmd, args := browserLaunchCommand("windows", url)
+
+		assert.Equal(t, "rundll32", cmd)
+		assert.Equal(t, []string{"url.dll,FileProtocolHandler", url}, args)
+	})
+
+	t.Run("darwin uses open", func(t *testing.T) {
+		cmd, args := browserLaunchCommand("darwin", url)
+
+		assert.Equal(t, "open", cmd)
+		assert.Equal(t, []string{url}, args)
+	})
+
+	t.Run("linux uses xdg-open", func(t *testing.T) {
+		cmd, args := browserLaunchCommand("linux", url)
+
+		assert.Equal(t, "xdg-open", cmd)
+		assert.Equal(t, []string{url}, args)
+	})
+}

--- a/store/tokens.go
+++ b/store/tokens.go
@@ -83,6 +83,20 @@ type TokenStore struct {
 	FilePath   string          `yaml:"-"`
 }
 
+func resolveHomeDir() string {
+	if homeDir := os.Getenv("HOME"); homeDir != "" {
+		return homeDir
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Println("Error getting home directory:", err)
+		return "."
+	}
+
+	return homeDir
+}
+
 // Creates a new TokenStore, loading from ~/.xurl (auto-migrating legacy JSON).
 func NewTokenStore() *TokenStore {
 	return NewTokenStoreWithCredentials("", "")
@@ -92,12 +106,7 @@ func NewTokenStore() *TokenStore {
 // client credentials into any app that was migrated without them (i.e. legacy
 // JSON migration where CLIENT_ID / CLIENT_SECRET came from env vars).
 func NewTokenStoreWithCredentials(clientID, clientSecret string) *TokenStore {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		fmt.Println("Error getting home directory:", err)
-		homeDir = "."
-	}
-
+	homeDir := resolveHomeDir()
 	filePath := filepath.Join(homeDir, ".xurl")
 
 	store := &TokenStore{


### PR DESCRIPTION
On Windows, xurl breaks OAuth2 authentication at the very first step because it opens the browser with a truncated authorize URL, so the PKCE flow cannot start correctly.

## Summary

- switch Windows browser launch from `cmd /c start` to `rundll32 url.dll,FileProtocolHandler` so the full OAuth2 authorize URL reaches the browser intact
- honor `HOME` before `os.UserHomeDir()` in the token store so home-directory based `.xurl` lookup and migration behave consistently across environments and tests
- add a small regression test around browser command construction so the Windows launch path is verified in unit tests

## Why this breaks on Windows

The existing Windows path launches the browser via `cmd /c start <url>`. OAuth2 authorize URLs contain `&` separators, and `cmd` treats those as command separators unless they are quoted/escaped in a shell-specific way. In practice, the browser only receives:

`https://x.com/i/oauth2/authorize?client_id=...`

That strips `redirect_uri`, `response_type`, `scope`, `state`, `code_challenge`, and `code_challenge_method`, so the PKCE flow fails before the user can authenticate.

## Test plan

- [x] `go test ./auth ./store`
- [x] unit test verifies the Windows browser-launch command keeps the full OAuth2 PKCE URL as a single argument
- [x] on Windows, `xurl auth oauth2 <username>` opens the browser with the full OAuth2 PKCE URL
- [x] completed OAuth2 authentication successfully on Windows after the browser-launch fix