### PR TITLE
feat(errors): add NewYAMLError and IsYAMLError functions

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -14,6 +14,7 @@ const (
 	ErrTypeJSON          = "JSON Error"
 	ErrTypeAuth          = "Auth Error"
 	ErrTypeTokenStore    = "Token Store Error"
+	ErrTypeYAML          = "YAML Error"
 )
 
 type Error struct {
@@ -74,6 +75,10 @@ func NewJSONError(cause error) *Error {
 	return NewError(ErrTypeJSON, cause.Error(), cause)
 }
 
+func NewYAMLError(cause error) *Error {
+	return NewError(ErrTypeYAML, cause.Error(), cause)
+}
+
 func NewAuthError(message string, cause error) *Error {
 	return NewError(ErrTypeAuth, message, cause)
 }
@@ -95,3 +100,4 @@ func IsIOError(err error) bool   { return IsErrorType(err, ErrTypeIO) }
 func IsAPIError(err error) bool  { return IsErrorType(err, ErrTypeAPI) }
 func IsJSONError(err error) bool { return IsErrorType(err, ErrTypeJSON) }
 func IsAuthError(err error) bool { return IsErrorType(err, ErrTypeAuth) }
+func IsYAMLError(err error) bool { return IsErrorType(err, ErrTypeYAML) }

--- a/store/tokens.go
+++ b/store/tokens.go
@@ -366,7 +366,7 @@ func (s *TokenStore) importFromTwurlrc(filePath string) error {
 	}
 
 	if err := yaml.Unmarshal(data, &twurlConfig); err != nil {
-		return errors.NewJSONError(err)
+		return errors.NewYAMLError(err)
 	}
 
 	app := s.activeAppOrCreate()


### PR DESCRIPTION
Add NewYAMLError and IsYAMLError functions to the errors package to support returning a proper YAML error when parsing twurlrc config fails, instead of the incorrect NewJSONError