### PR TITLE
feat(read-post): request note_tweet and article fields for long-form …

### DIFF
--- a/api/shortcuts.go
+++ b/api/shortcuts.go
@@ -152,7 +152,7 @@ func ReadPost(client Client, postID string, opts RequestOptions) (json.RawMessag
 	postID = ResolvePostID(postID)
 
 	opts.Method = "GET"
-	opts.Endpoint = fmt.Sprintf("/2/tweets/%s?tweet.fields=created_at,public_metrics,conversation_id,in_reply_to_user_id,referenced_tweets,entities,attachments&expansions=author_id,referenced_tweets.id&user.fields=username,name,verified", postID)
+	opts.Endpoint = fmt.Sprintf("/2/tweets/%s?tweet.fields=created_at,public_metrics,conversation_id,in_reply_to_user_id,referenced_tweets,entities,attachments,note_tweet,article&expansions=author_id,referenced_tweets.id&user.fields=username,name,verified", postID)
 	opts.Data = ""
 
 	return client.SendRequest(opts)


### PR DESCRIPTION
 ## Summary

  - Adds `note_tweet` and `article` to the `tweet.fields` parameter in `ReadPost`
  - The X API will now return long-form article and Notes content when present on a post
  - No change to the public function signature — callers receive the additional fields as part of the
  existing raw JSON response

  ## Test plan

  - [ ] Run `xurl read <post-id>` on a post that is an X Note — verify `note_tweet` field appears in
  the response
  - [ ] Run `xurl read <post-id>` on a post that links to a long-form article — verify `article` field
   appears in the response
  - [ ] Run `xurl read <post-id>` on a regular post — verify existing behaviour is unchanged
