### PR TITLE
fix: use basic auth header for OAuth2 token exchange

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -195,8 +195,9 @@ func (a *Auth) OAuth2Flow(username string) (string, error) {
 		ClientID:     a.clientID,
 		ClientSecret: a.clientSecret,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  a.authURL,
-			TokenURL: a.tokenURL,
+			AuthURL:   a.authURL,
+			TokenURL:  a.tokenURL,
+			AuthStyle: oauth2.AuthStyleInHeader,
 		},
 		RedirectURL: a.redirectURI,
 		Scopes:      getOAuth2Scopes(),


### PR DESCRIPTION
## Summary

Fix OAuth2 token exchange against X by sending the client credentials via the HTTP Basic authorization header.

Without this, X rejects the token exchange with:

```text
unauthorized_client: Missing valid authorization header
```

## Why

The OAuth2 config currently leaves `Endpoint.AuthStyle` unset, which allows the OAuth2 package to choose/discover how client credentials are sent. In practice, X expects the token request to authenticate the client using the `Authorization` header.

Setting:

```go
AuthStyle: oauth2.AuthStyleInHeader
```

matches X's expected OAuth2 token exchange behavior.

## Verification

- Reproduced failure locally with X OAuth2 app auth: `TokenExchangeError`, `Missing valid authorization header`
- Applied this patch and successfully completed OAuth2 for `@ethanmlam`
- Verified `xurl whoami` returns the authenticated X user
- Ran `go test ./...`
