### PR TITLE
warn: oauth2 without --app saves token to credential-less app

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -65,6 +65,35 @@ func createAuthOAuth2Cmd(a *auth.Auth) *cobra.Command {
 			if len(args) > 0 {
 				username = args[0]
 			}
+
+			// Warn when --app is not specified and the default app has no
+			// client credentials but another registered app does.  Tokens
+			// saved to a credential-less app cannot be refreshed, causing
+			// cryptic 401 errors on all subsequent API calls.
+			if a.AppName() == "" {
+				defaultApp := a.TokenStore.GetApp("")
+				hasCredentials := defaultApp != nil && defaultApp.ClientID != ""
+				if !hasCredentials {
+					var credentialed []string
+					for _, name := range a.TokenStore.ListApps() {
+						app := a.TokenStore.GetApp(name)
+						if app != nil && app.ClientID != "" {
+							credentialed = append(credentialed, name)
+						}
+					}
+					if len(credentialed) > 0 {
+						fmt.Fprintf(os.Stderr, "\033[33m⚠️  No --app specified. The OAuth2 token will be saved to the \"default\" app,\n")
+						fmt.Fprintf(os.Stderr, "    which has no client credentials stored. API calls will fail with 401 errors.\n\n")
+						fmt.Fprintf(os.Stderr, "    App(s) with credentials available:\n")
+						for _, name := range credentialed {
+							app := a.TokenStore.GetApp(name)
+							fmt.Fprintf(os.Stderr, "      --app %s  [client_id: %s…]\n", name, truncate(app.ClientID, 8))
+						}
+						fmt.Fprintf(os.Stderr, "\n    Run instead:  xurl auth oauth2 --app %s\n\n", credentialed[0])
+					}
+				}
+			}
+
 			_, err := a.OAuth2Flow(username)
 			if err != nil {
 				fmt.Println("OAuth2 authentication failed:", err)


### PR DESCRIPTION
## Problem

When a user registers an app with client credentials:

```bash
xurl auth apps add my-app --client-id X --client-secret Y
```

And then runs the OAuth2 flow without `--app`:

```bash
xurl auth oauth2    # missing --app my-app
```

The browser opens, the user authorizes, and the CLI prints:

> OAuth2 authentication successful!

But the token lands in the built-in `default` profile — which has **no client credentials**. Every subsequent API call fails with a cryptic `401 Unauthorized`, and nothing in the error message points to the missing `--app` as the root cause.

This is the # 1 user footgun reported by downstream consumers (Hermes Agent, OpenClaw, direct CLI users).

## Fix

Before running the OAuth2 flow, check whether the target app (default, when `--app` is omitted) has stored client credentials. If it doesn't, but another registered app does, print a warning to stderr:

```
No --app specified. The OAuth2 token will be saved to the "default" app,
    which has no client credentials stored. API calls will fail with 401 errors.

    App(s) with credentials available:
      --app my-app  [client_id: VUttdG9P...]

    Run instead:  xurl auth oauth2 --app my-app
```

- Non-breaking: the OAuth flow still runs. Users intentionally using the default app with env-var or manual credentials aren't blocked.
- Warning goes to **stderr** so scripted pipelines can still parse stdout.
- Only fires when there IS a better alternative available (no false positives).

## Test plan

1. Register an app: `xurl auth apps add my-app --client-id X --client-secret Y`
2. Run `xurl auth oauth2` without `--app` → **warning appears**
3. Run `xurl auth oauth2 --app my-app` → **no warning** (correct usage)
4. No apps registered → `xurl auth oauth2` → **no warning** (nothing to suggest)