### PR TITLE
docs: clarify oauth2 app selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All user-visible bugs and enhancements should be recorded here.
 
 ## Unreleased
 
-Last updated: 2026-04-19 23:48:20 CEST
+Last updated: 2026-05-14 11:38:34 PDT
 
 ### Fixed
 
@@ -16,6 +16,7 @@ Last updated: 2026-04-19 23:48:20 CEST
 
 ### Enhanced
 
+- [2026-05-14 11:38:34 PDT] Documentation and the bundled `xurl` skill now recommend authenticating registered apps with `xurl auth oauth2 --app APP_NAME` and explain that omitting `--app` saves the token to the current default app.
 - [2026-04-19 23:08:51 CEST] OAuth2 tokens can now be retained without a discovered username label when X’s `/2/users/me` lookup is unavailable. Status output makes that state visible as `(unknown user)` instead of silently dropping the token.
 - [2026-04-19 23:08:51 CEST] Repo documentation now describes the effective redirect URI as the source of callback host, port, and path, calls out explicit username authentication as the safer fallback when username discovery is unreliable, and documents the new stored `redirect_uri` behavior.
 - [2026-04-19 23:08:51 CEST] Apps can now store a per-app `redirect_uri` in `~/.xurl`, `REDIRECT_URI` from the environment still takes precedence, and `xurl auth apps redirect-uri get/set` plus `auth apps update --redirect-uri` make that configuration visible and editable from the CLI.

--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ xurl auth apps add dev-app  --client-id DEV_ID  --client-secret DEV_SECRET
 ```bash
 xurl auth apps add my-app --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
 ```
-4. Get your access keys:
+4. Get your access keys for the registered app:
 ```bash
-xurl auth oauth2
+xurl auth oauth2 --app my-app
 ```
+
+If you omit `--app`, the token is saved to the current default app. You can also run `xurl auth default my-app` first and then use `xurl auth oauth2`.
 
 If X returns a `client-forbidden` / `client-not-enrolled` error even though auth completed successfully, check the app’s package and environment in the X developer console. On current X platform setup, the working fix was:
 
@@ -97,7 +99,7 @@ Without that enrollment step, `xurl whoami` and other `/2/*` reads can fail even
 If X does not return your username reliably through `/2/users/me`, authenticate with an explicit handle instead:
 
 ```bash
-xurl auth oauth2 YOUR_USERNAME
+xurl auth oauth2 --app my-app YOUR_USERNAME
 ```
 
 That keeps the OAuth2 token associated with the expected username and also gives shortcut commands a fallback when `/2/users/me` is unavailable.

--- a/SKILL.md
+++ b/SKILL.md
@@ -29,11 +29,13 @@ Before using any command you must be authenticated. Run `xurl auth status` to ch
 ### Register an app (recommended)
 
 App credential registration must be done manually by the user outside the agent/LLM session.
-After credentials are registered, authenticate with:
+After credentials are registered, authenticate against the app that holds those credentials:
 
 ```bash
-xurl auth oauth2
+xurl auth oauth2 --app APP_NAME
 ```
+
+You can also run `xurl auth default APP_NAME` first and then use `xurl auth oauth2`.
 
 For multiple pre-configured apps, switch between them:
 ```bash
@@ -385,7 +387,7 @@ xurl --app staging /2/users/me         # one-off request against staging
 - Non‑zero exit code on any error.
 - API errors are printed as JSON to stdout (so you can still parse them).
 - Auth errors suggest re‑running `xurl auth oauth2` or checking your tokens.
-- If a command requires your user ID (like, repost, bookmark, follow, etc.), xurl will automatically fetch it via `/2/users/me`. When that endpoint is unreliable, use `--username USERNAME` or authenticate with `xurl auth oauth2 USERNAME` so xurl can fall back to username lookup.
+- If a command requires your user ID (like, repost, bookmark, follow, etc.), xurl will automatically fetch it via `/2/users/me`. When that endpoint is unreliable, use `--username USERNAME` or authenticate with `xurl auth oauth2 --app APP_NAME USERNAME` so xurl can fall back to username lookup.
 - If X returns `client-forbidden` / `client-not-enrolled` after successful auth, check the app’s X developer-console package and environment. In current testing, moving the app to `Pay-per-use` and `Production` fixed `/2/*` read failures without changing local `xurl` auth data.
 
 ---


### PR DESCRIPTION
## Summary
Updates documentation to match the new OAuth2 warning behavior for registered apps introduced in this PR: https://github.com/xdevplatform/xurl/pull/74

- Recommends `xurl auth oauth2 --app my-app` after registering app credentials
- Explains that omitting `--app` saves the token to the current default app
- Updates the explicit-username OAuth2 example to include `--app`
- Updates the bundled `xurl` skill guidance
- Records the docs change in the changelog

## Test Plan
- Ran `go test ./...`
- Ran `git diff --check`