### PR TITLE
docs(mcp): correct mcp --help to document first-run browser login (v1.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All user-visible bugs and enhancements should be recorded here.
 
+## v1.2.2 - 2026-06-29
+
+### Fixed
+
+- [2026-06-29] `mcp --help` no longer contradicts the bridge's behavior. The v1.2.1 help text still said the bridge "never opens a browser itself; if no token exists it exits with that instruction", but v1.2.1 changed the bridge to open the browser for a first-run OAuth2 login when no token is cached. The help now documents that, and points remote/headless hosts to `xurl auth oauth2 [--app NAME] --headless`.
+
 ## v1.2.1 - 2026-06-29
 
 ### Changed

--- a/cli/mcp.go
+++ b/cli/mcp.go
@@ -736,10 +736,11 @@ session id is maintained across requests.
 
 The access token is resolved exactly like 'xurl token': an existing token is
 refreshed automatically as it expires (including a forced refresh on a 401).
-Authenticate once before starting the bridge with 'xurl auth oauth2 [--app NAME]'
-(add --headless on a remote/headless machine). The bridge never opens a browser
-itself; if no token exists it exits with that instruction. All diagnostics go to
-stderr so stdout stays a clean JSON-RPC channel.
+If no token is cached, the bridge opens the browser for an interactive OAuth2
+login on startup and blocks until it completes, so a first run needs no separate
+'xurl auth oauth2' step. On a remote/headless machine without a browser,
+authenticate first with 'xurl auth oauth2 [--app NAME] --headless'. All
+diagnostics go to stderr so stdout stays a clean JSON-RPC channel.
 
 If URL is omitted it defaults to ` + defaultMCPURL + `.
 


### PR DESCRIPTION
## What

Fixes the `xurl mcp` command's `--help` (`Long`) text, which shipped in v1.2.1 still claiming:

> The bridge never opens a browser itself; if no token exists it exits with that instruction.

That contradicts the v1.2.1 behavior (Option A): `bootstrap()` now opens the browser for a first-run OAuth2 login when no token is cached. The stale help could mislead no-install (`npx … mcp`) users into thinking they must run `xurl auth oauth2` first.

## Change

- `cli/mcp.go`: rewrite the `Long` help to document the first-run browser login and point remote/headless hosts at `xurl auth oauth2 [--app NAME] --headless`.
- `CHANGELOG.md`: add a `v1.2.2` entry.

Docs-only; no behavior change.

## Verification

- `go build ./... && go vet ./... && go test ./...` all green.
- Validated the fresh-user (no install, no `~/.xurl`) path end-to-end: `npx @xdevplatform/xurl@1.2.1 mcp` in an isolated HOME with creds in env → bridge reported `no valid OAuth2 token; opening the browser`, completed login, then handshook and listed all 27 tools.