### PR TITLE
feat(auth): add broadcast.read and broadcast.write OAuth2 scopes

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -679,6 +679,7 @@ func getOAuth2Scopes() []string {
 		"like.read",
 		"users.email",
 		"dm.read",
+		"broadcast.read",
 	}
 
 	writeScopes := []string{
@@ -692,6 +693,7 @@ func getOAuth2Scopes() []string {
 		"list.write",
 		"media.write",
 		"dm.write",
+		"broadcast.write",
 	}
 
 	otherScopes := []string{

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -156,6 +156,8 @@ func TestGetOAuth2Scopes(t *testing.T) {
 	// Check for some common scopes
 	assert.Contains(t, scopes, "tweet.read", "Expected 'tweet.read' scope")
 	assert.Contains(t, scopes, "users.read", "Expected 'users.read' scope")
+	assert.Contains(t, scopes, "broadcast.read", "Expected 'broadcast.read' scope")
+	assert.Contains(t, scopes, "broadcast.write", "Expected 'broadcast.write' scope")
 }
 
 func TestCredentialResolutionPriority(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `broadcast.read` and `broadcast.write` to the OAuth2 scope list requested during `xurl auth oauth2`, supporting the new livestreaming broadcast endpoints (e.g. `POST /2/broadcasts/:id/chat`).
- Both scopes are now registered in the authorization server's production scope catalog.

## Test plan
- [x] `go build ./...`
- [x] `go test ./auth/` (extended `TestGetOAuth2Scopes` to assert both new scopes)

Made with [Cursor](https://cursor.com)