### PR TITLE
Include long-form tweet fields in read shortcut

### DIFF
--- a/api/shortcuts.go
+++ b/api/shortcuts.go
@@ -164,7 +164,7 @@ func ReadPost(client Client, postID string, opts RequestOptions) (json.RawMessag
 	postID = ResolvePostID(postID)
 
 	opts.Method = "GET"
-	opts.Endpoint = fmt.Sprintf("/2/tweets/%s?tweet.fields=created_at,public_metrics,conversation_id,in_reply_to_user_id,referenced_tweets,entities,attachments&expansions=author_id,referenced_tweets.id&user.fields=username,name,verified", postID)
+	opts.Endpoint = fmt.Sprintf("/2/tweets/%s?tweet.fields=created_at,public_metrics,conversation_id,in_reply_to_user_id,referenced_tweets,entities,attachments,note_tweet,article&expansions=author_id,referenced_tweets.id&user.fields=username,name,verified", postID)
 	opts.Data = ""
 
 	return client.SendRequest(opts)

--- a/api/shortcuts_test.go
+++ b/api/shortcuts_test.go
@@ -88,8 +88,14 @@ func setupShortcutServer() *httptest.Server {
 
 		// GET /2/tweets/:id — read post
 		case strings.HasPrefix(r.URL.Path, "/2/tweets/") && r.Method == "GET":
+			fields := r.URL.Query().Get("tweet.fields")
+			if !strings.Contains(fields, "note_tweet") || !strings.Contains(fields, "article") {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(`{"errors":[{"message":"missing long-form tweet fields"}]}`))
+				return
+			}
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"data":{"id":"123","text":"existing post","public_metrics":{"like_count":5}}}`))
+			w.Write([]byte(`{"data":{"id":"123","text":"existing post","note_tweet":{"text":"full long-form post"},"public_metrics":{"like_count":5}}}`))
 
 		// GET /2/users/me
 		case r.URL.Path == "/2/users/me" && r.Method == "GET":
@@ -216,12 +222,16 @@ func TestReadPost(t *testing.T) {
 
 	var result struct {
 		Data struct {
-			ID   string `json:"id"`
-			Text string `json:"text"`
+			ID        string `json:"id"`
+			Text      string `json:"text"`
+			NoteTweet struct {
+				Text string `json:"text"`
+			} `json:"note_tweet"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(resp, &result))
 	assert.Equal(t, "123", result.Data.ID)
+	assert.Equal(t, "full long-form post", result.Data.NoteTweet.Text)
 }
 
 // ---- SearchPosts ----


### PR DESCRIPTION
## Summary

This updates the `xurl read` shortcut to request X's long-form post fields:

- `note_tweet`
- `article`

X can return a shortened legacy/preview value in `data.text` for Premium long-form posts, while the full rendered body is available in `data.note_tweet.text` (or, for article-style posts, `data.article`). Without requesting those fields, `xurl read` can make a valid long post look truncated to CLI users and automation.

## Why

We hit this with a Premium account posting a long-form podcast announcement. The post rendered correctly on x.com, but the API response from `xurl post` / `xurl read` only showed the shortened `data.text` preview. A raw request with `tweet.fields=note_tweet,article` returned the full body under `data.note_tweet.text`.

Requesting these fields by default keeps the existing JSON shape intact and simply exposes the additional long-form payload when X returns it.

## Changes

- Adds `note_tweet,article` to the `tweet.fields` used by `ReadPost`.
- Updates the shortcut test server to require those fields for read requests.
- Extends `TestReadPost` to assert that a `note_tweet.text` payload is preserved in the returned JSON.

## Test plan

- `gofmt -w api/shortcuts.go api/shortcuts_test.go`
- `go test ./...`
- `go build ./...`
- Manually verified against the X API that requesting `tweet.fields=note_tweet,article` returns the full long-form post body in `data.note_tweet.text` for a real Premium long post while `data.text` remains shortened.